### PR TITLE
fixes #25: group margin fix

### DIFF
--- a/d2l-image-action-group.html
+++ b/d2l-image-action-group.html
@@ -10,16 +10,18 @@
 			:host ::content > a[is="d2l-image-action-link"] {
 				margin-right: 1.5rem;
 			}
-			:host ::content > *:last-child {
+			:host ::content > button[is="d2l-image-action"]:last-child,
+			:host ::content > a[is="d2l-image-action-link"]:last-child {
 				margin-right: 0;
 			}
-			:host-context([dir="rtl"]) ::content button[is="d2l-image-action"],
-			:host-context([dir="rtl"]) ::content a[is="d2l-image-action-link"] {
-				margin-right: 0;
-				margin-left: 1.5rem;
+			:host-context([dir="rtl"]) ::content > button[is="d2l-image-action"],
+			:host-context([dir="rtl"]) ::content > a[is="d2l-image-action-link"] {
+				margin-right: 0 !important;
+				margin-left: 1.5rem !important;
 			}
-			:host-context([dir="rtl"]) ::content *:last-child {
-				margin-left: 0;
+			:host-context([dir="rtl"]) ::content > button[is="d2l-image-action"]:last-child,
+			:host-context([dir="rtl"]) ::content > a[is="d2l-image-action-link"]:last-child {
+				margin-left: 0 !important;
 			}
 		</style>
 		<content></content>


### PR DESCRIPTION
@njostonehouse, @dbatiste: I hate using `!important` here, I'm hoping you guys can think of another way to do this. Image-actions can be one of two elements -- either a `<button>` or an `<a>`, each with a custom element applied to them.

For groups of actions, I want to apply a right-margin on every child of the group except the last one. I'd like to use this CSS:

```
:host ::content > * {
    margin-right: 1.5rem;
}
:host ::content > *:last-child {
    margin-right: 0;
}
```

The problem is that the children themselves have a `0` margin and in shady-dom, Polymer applies that using a CSS class. And that selector has a higher specificity than the one above, so you always end up with a `0` margin. All is good with shadow-dom. `!important` seems to be the only way to increase the specificity here. :(